### PR TITLE
Add CDI correction feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 O iBovComparator tem como objetivo obter dados sobre o índice Bovespa (composto das cotações de ações mais negociadas na atual B3), obter também dados sobre a inflação (índice de preços ao consumidor amplo, IPCA), também cotações do Dólar e do Bitcoin (BTC).
 
-Com todos esses dados em mãos, gerar gráficos do iBov, e variações dele corrigidos pelo IPCA, pelo Dólar e pelo BTC.
+Com todos esses dados em mãos, gerar gráficos do iBov, e variações dele corrigidos pelo IPCA, pelo Dólar, pelo BTC e pelo CDI/Selic.
 
 Esta aplicação está configurada para ser executada em um Notebook Python. Sugiro a utilização do Google Colab/Research.

--- a/iBovComparator.ipynb
+++ b/iBovComparator.ipynb
@@ -21,7 +21,8 @@ def fetch_bcb_series(series_id: int, start='2010-01-01', end=None) -> pd.DataFra
         f"https://api.bcb.gov.br/dados/serie/bcdata.sgs.{series_id}/dados"
         f"?formato=json&dataInicial={start_date}&dataFinal={end_date}"
     )
-    r = requests.get(url)
+    headers = {"Accept": "application/json", "User-Agent": "Mozilla/5.0"}
+    r = requests.get(url, headers=headers)
     r.raise_for_status()
     df = pd.DataFrame(r.json())
     df['data'] = pd.to_datetime(df['data'], dayfirst=True)

--- a/iBovComparator.ipynb
+++ b/iBovComparator.ipynb
@@ -13,9 +13,13 @@ def fetch_bcb_series(series_id: int, start='2010-01-01', end=None) -> pd.DataFra
     """Return Central Bank of Brazil time series as a dataframe."""
     if end is None:
         end = datetime.today().strftime('%Y-%m-%d')
+
+    start_date = pd.to_datetime(start).strftime('%d/%m/%Y')
+    end_date = pd.to_datetime(end).strftime('%d/%m/%Y')
+
     url = (
         f"https://api.bcb.gov.br/dados/serie/bcdata.sgs.{series_id}/dados"
-        f"?formato=json&dataInicial={start}&dataFinal={end}"
+        f"?formato=json&dataInicial={start_date}&dataFinal={end_date}"
     )
     r = requests.get(url)
     r.raise_for_status()

--- a/iBovComparator.ipynb
+++ b/iBovComparator.ipynb
@@ -6,11 +6,33 @@ import yfinance as yf
 import sidrapy
 import pandas as pd
 import plotly.graph_objects as go
+import requests
+from datetime import datetime
+
+def fetch_bcb_series(series_id: int, start='2010-01-01', end=None) -> pd.DataFrame:
+    """Return Central Bank of Brazil time series as a dataframe."""
+    if end is None:
+        end = datetime.today().strftime('%Y-%m-%d')
+    url = (
+        f"https://api.bcb.gov.br/dados/serie/bcdata.sgs.{series_id}/dados"
+        f"?formato=json&dataInicial={start}&dataFinal={end}"
+    )
+    r = requests.get(url)
+    r.raise_for_status()
+    df = pd.DataFrame(r.json())
+    df['data'] = pd.to_datetime(df['data'], dayfirst=True)
+    df['valor'] = pd.to_numeric(df['valor'].str.replace(',', '.'))
+    return df.set_index('data')
 
 # 1. Buscar dados diários desde 2010
 ibov = yf.download('^BVSP', start='2010-01-01')
 usdbrl = yf.download('USDBRL=X', start='2010-01-01')
 btc = yf.download('BTC-USD', start='2010-01-01')
+
+# 1b. Buscar CDI diario via API do Banco Central
+cdi = fetch_bcb_series(12, start='2010-01-01')
+cdi['cdi_factor'] = (1 + cdi['valor'] / 100) ** (1 / 252)
+cdi['cdi_accum'] = cdi['cdi_factor'].cumprod()
 
 # 2. Forçar uso da coluna 'Close' corretamente
 ibov = ibov['Close'] if 'Close' in ibov.columns else ibov.squeeze()
@@ -58,13 +80,15 @@ df = pd.concat([
     pd.DataFrame(ibov.squeeze()).rename(columns={ibov.squeeze().name: 'Ibovespa'}),
     pd.DataFrame(usdbrl.squeeze()).rename(columns={usdbrl.squeeze().name: 'USD/BRL'}),
     pd.DataFrame(btc.squeeze()).rename(columns={btc.squeeze().name: 'BTC/USD'}),
-    ipca_df
-], axis=1).dropna(subset=['Ibovespa', 'USD/BRL', 'ipca_factor'])
+    ipca_df,
+    cdi[['cdi_accum']].rename(columns={'cdi_accum': 'CDI_factor'})
+], axis=1).dropna(subset=['Ibovespa', 'USD/BRL', 'ipca_factor', 'CDI_factor'])
 
 # 5. Calcular indicadores reais
 df['Ibovespa_Real'] = df['Ibovespa'] / df['ipca_factor']
 df['Ibovespa_USD'] = df['Ibovespa'] / df['USD/BRL']
 df['Ibovespa_BTC'] = df['Ibovespa_USD'] / df['BTC/USD']
+df['Ibovespa_CDI'] = df['Ibovespa'] / df['CDI_factor']
 
 # 6. Normalizar as curvas com base em 2010
 df_norm = pd.DataFrame(index=df.index)
@@ -73,6 +97,7 @@ base_ibov = df['Ibovespa'].iloc[0]
 df_norm['Ibovespa'] = df['Ibovespa'] / base_ibov
 df_norm['Ibovespa_Real'] = df['Ibovespa_Real'] / df['Ibovespa_Real'].iloc[0]
 df_norm['Ibovespa_USD'] = df['Ibovespa_USD'] / df['Ibovespa_USD'].iloc[0]
+df_norm['Ibovespa_CDI'] = df['Ibovespa_CDI'] / df['Ibovespa_CDI'].iloc[0]
 
 # Corrigir BTC: normalizar a partir da 1ª data válida e alinhar a escala
 if df['Ibovespa_BTC'].notna().any():
@@ -94,6 +119,8 @@ fig.add_trace(go.Scatter(x=df_norm.index, y=df_norm['Ibovespa_USD'] * base_ibov,
                          mode='lines', name='Em Dólar', line=dict(color='orange')))
 fig.add_trace(go.Scatter(x=df_norm.index, y=df_norm['Ibovespa_BTC'] * base_ibov,
                          mode='lines', name='Em Bitcoin (desde 2014)', line=dict(color='purple')))
+fig.add_trace(go.Scatter(x=df_norm.index, y=df_norm['Ibovespa_CDI'] * base_ibov,
+                         mode='lines', name='Corrigido pelo CDI', line=dict(color='red')))
 
 fig.update_layout(
     title='Ibovespa em diferentes unidades (interativo, diário)',


### PR DESCRIPTION
## Summary
- fetch daily CDI from Brazil's Central Bank API
- calculate cumulative CDI factor and Ibovespa adjusted by CDI
- show CDI-corrected series on graph
- document CDI/Selic support in README

## Testing
- `python -m py_compile iBovComparator.ipynb` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68410f7c55b0832da25fbaaa3e209138